### PR TITLE
Add opts object for shotQueue.add. Give worker 60 seconds to complete…

### DIFF
--- a/lib/queue.js
+++ b/lib/queue.js
@@ -94,6 +94,8 @@ api.close = function close (callback) {
 api.queue = function queue (request) {
   log.info(request, 'Queing request to process');
   shotQueue.add(request);
+  opts = { timeout: 60000 };
+  shotQueue.add(request, opts);
 };
 
 api.requestQueueCount = function requestQueueCount (callback) {

--- a/lib/queue.js
+++ b/lib/queue.js
@@ -94,7 +94,7 @@ api.close = function close (callback) {
 api.queue = function queue (request) {
   log.info(request, 'Queing request to process');
   shotQueue.add(request);
-  let opts = { timeout: 60000 };
+  var opts = { timeout: 60000 };
   shotQueue.add(request, opts);
 };
 

--- a/lib/queue.js
+++ b/lib/queue.js
@@ -94,7 +94,7 @@ api.close = function close (callback) {
 api.queue = function queue (request) {
   log.info(request, 'Queing request to process');
   shotQueue.add(request);
-  opts = { timeout: 60000 };
+  let opts = { timeout: 60000 };
   shotQueue.add(request, opts);
 };
 


### PR DESCRIPTION
… each job before killing

Fixes [worker-screenshot issue #4.](https://github.com/cloudytimemachine/worker-screenshot/issues/4)